### PR TITLE
Fix panic on resize

### DIFF
--- a/vt100.go
+++ b/vt100.go
@@ -329,6 +329,11 @@ func (v *VT100) advance() {
 }
 
 func (v *VT100) scrollIfNeeded() {
+	if v.Cursor.X >= v.Width {
+		v.Cursor.X = 0
+		v.Cursor.Y++
+	}
+
 	if v.Cursor.Y >= v.Height {
 		first := v.Content[0]
 		copy(v.Content, v.Content[1:])

--- a/vt100_test.go
+++ b/vt100_test.go
@@ -1,0 +1,18 @@
+package vt100
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResize(t *testing.T) {
+	vt := NewVT100(1, 2)
+
+	err := vt.Process(runeCommand(rune(65)))
+	assert.NoError(t, err)
+
+	vt.Resize(1, 1)
+	err = vt.Process(runeCommand(rune(65)))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
When running the `docker buildx build` command and resizing the terminal during a progress bar update I encountered the following panic:

```
goroutine 13 [running]:
github.com/tonistiigi/vt100.(*VT100).put(0x213b580?, 0x4f6801?)
        github.com/tonistiigi/vt100@v0.0.0-20210615222946-8066bb97264f/vt100.go:312 +0x147
github.com/tonistiigi/vt100.runeCommand.display(...)
        github.com/tonistiigi/vt100@v0.0.0-20210615222946-8066bb97264f/command.go:44
github.com/tonistiigi/vt100.(*VT100).Process(...)
        github.com/tonistiigi/vt100@v0.0.0-20210615222946-8066bb97264f/vt100.go:252
github.com/tonistiigi/vt100.(*VT100).Write(0xc00026ae70, {0xc0002b6750?, 0x1, 0xd?})
        github.com/tonistiigi/vt100@v0.0.0-20210615222946-8066bb97264f/vt100.go:239 +0x171
github.com/moby/buildkit/util/progress/progressui.(*trace).update(0xc0005ebec0, 0xc000e0d200, 0x8c)
        github.com/moby/buildkit@v0.11.0-rc3.0.20230523090158-212ab16a39b1/util/progress/progressui/display.go:569 +0x1591
github.com/moby/buildkit/util/progress/progressui.DisplaySolveStatus({0x26d60c0, 0xc000486690}, {0x26e2628, 0xc000684690}, {0x26b92e0, 0xc000012020}, 0xc00087a0c0, {0xc0006943b0, 0x1, 0x1})
        github.com/moby/buildkit@v0.11.0-rc3.0.20230523090158-212ab16a39b1/util/progress/progressui/display.go:91 +0x4bd
github.com/docker/buildx/util/progress.NewPrinter.func1()
        github.com/docker/buildx/util/progress/printer.go:126 +0x1c5
created by github.com/docker/buildx/util/progress.NewPrinter
        github.com/docker/buildx/util/progress/printer.go:114 +0x338
```

This seems to happen because the cursor in vt100 is not updated during resize.

This commit fixes that by checking if the cursor needs adjustment on the X-axis in the scrollIfNeeded method.

I also added a minimal test that panics without the fix.