### PR TITLE
Reduce Format as well as Content struct when resizing in y

### DIFF
--- a/vt100.go
+++ b/vt100.go
@@ -200,6 +200,7 @@ func (v *VT100) Resize(y, x int) {
 		v.Height = y
 	} else if y < v.Height {
 		v.Content = v.Content[:y]
+		v.Format = v.Format[:y]
 		v.Height = y
 	}
 


### PR DESCRIPTION
I *think* this was the cause of me causing buildkit panics when aggressively resizing the window while testing the bounds patch for BUILDX_TTY_LOG_LINES:  

When resizing in y, the Content ends up with less rows than Format since it wasn't getting sliced.
Then, when resizing in x, we assume Content and Format have the same number of rows (we loop over the number
of rows in Content).  So Format was ending up as a non-rectangular array, and then I ran off the end of it.


